### PR TITLE
Add initial CICD

### DIFF
--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -1,0 +1,25 @@
+# This workflow will do a clean install of node dependencies, cache/restore them, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Run Unit Tests For PR
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [16.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'node_modules'
+    - run: yarn
+    - run: yarn test

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -20,6 +20,8 @@ jobs:
       uses: actions/setup-node@v2
       with:
         node-version: ${{ matrix.node-version }}
-        cache: 'node_modules'
+        # cache: 'npm'
+        # cache: 'node_modules'
+        cache: 'yarn'
     - run: yarn
     - run: yarn test

--- a/package.json
+++ b/package.json
@@ -8,22 +8,23 @@
 	},
 	"private": true,
 	"dependencies": {
-		"@testing-library/jest-dom": "^5.11.4",
-		"@testing-library/react": "^11.1.0",
-		"@testing-library/user-event": "^12.1.10",
-		"@types/jest": "^26.0.15",
-		"@types/node": "^12.0.0",
-		"@types/react": "^17.0.0",
-		"@types/react-dom": "^17.0.0",
 		"react": "^17.0.2",
 		"react-dom": "^17.0.2",
 		"react-router-dom": "^5.3.0",
-		"react-scripts": "4.0.3",
 		"typescript": "^4.1.2",
-		"web-vitals": "^1.0.1"
+		"web-vitals": "^2.1.2"
 	},
 	"devDependencies": {
-		"@types/react-router-dom": "^5.3.1"
+		"@testing-library/dom": "^8.10.1",
+		"@testing-library/jest-dom": "^5.14.1",
+		"@testing-library/react": "^12.1.2",
+		"@testing-library/user-event": "^13.5.0",
+		"@types/jest": "^27.0.2",
+		"@types/node": "^12.0.0",
+		"@types/react": "^17.0.2",
+		"@types/react-dom": "^17.0.2",
+		"@types/react-router-dom": "^5.3.2",
+		"react-scripts": "4.0.3"
 	},
 	"scripts": {
 		"build": "react-scripts build",

--- a/package.json
+++ b/package.json
@@ -26,10 +26,12 @@
 		"@types/react-router-dom": "^5.3.1"
 	},
 	"scripts": {
-		"start": "react-scripts start",
 		"build": "react-scripts build",
-		"test": "react-scripts test",
-		"eject": "react-scripts eject"
+		"eject": "react-scripts eject",
+		"snaps": "react-scripts test --watchAll=false -u",
+		"start": "react-scripts start",
+		"test": "react-scripts test --watchAll=false",
+		"test-watch": "react-scripts test"
 	},
 	"eslintConfig": {
 		"extends": [

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
 		"eject": "react-scripts eject",
 		"snaps": "react-scripts test --watchAll=false -u",
 		"start": "react-scripts start",
-		"test": "react-scripts test --watchAll=false",
+		"test": "react-scripts test --watchAll=false --collect-coverage",
 		"test-watch": "react-scripts test"
 	},
 	"eslintConfig": {

--- a/src/App/App.test.tsx
+++ b/src/App/App.test.tsx
@@ -39,10 +39,10 @@ describe('App', () => {
 	})
 })
 
-describe('App w/ initialTab=2', () => {
+describe('App w/ initialTab=2 when loaded', () => {
 	let comp: RenderResult
 
-	beforeEach(() => {
+	beforeEach(async () => {
 		comp = render(
 			<MemoryRouter initialEntries={['/tabs/2']} initialIndex={0}>
 				<Route path={['/tabs/:tabId', '/tabs', '/']}>
@@ -50,17 +50,19 @@ describe('App w/ initialTab=2', () => {
 				</Route>
 			</MemoryRouter>
 		)
+
+		await waitFor(() => comp.getByTestId('app'))
 	})
 
-	it('matches loading snapshot', () => {
+	it('matches snapshot', () => {
 		expect(comp.asFragment()).toMatchSnapshot()
 	})
 })
 
-describe('App w/ initialTab=3', () => {
+describe('App w/ initialTab=3 when loaded', () => {
 	let comp: RenderResult
 
-	beforeEach(() => {
+	beforeEach(async () => {
 		comp = render(
 			<MemoryRouter initialEntries={['/tabs/3']} initialIndex={0}>
 				<Route path={['/tabs/:tabId', '/tabs', '/']}>
@@ -68,9 +70,11 @@ describe('App w/ initialTab=3', () => {
 				</Route>
 			</MemoryRouter>
 		)
+
+		await waitFor(() => comp.getByTestId('app'))
 	})
 
-	it('matches loading snapshot', () => {
+	it('matches snapshot', () => {
 		expect(comp.asFragment()).toMatchSnapshot()
 	})
 })

--- a/src/App/App.test.tsx
+++ b/src/App/App.test.tsx
@@ -1,9 +1,40 @@
 import React from 'react'
-import { render, screen } from '@testing-library/react'
+import { render, RenderResult, waitFor } from '@testing-library/react'
 import { App } from './App'
+import { MemoryRouter, Route } from 'react-router-dom'
 
-test('renders learn react link', () => {
-	render(<App />)
-	const linkElement = screen.getByText(/learn react/i)
-	expect(linkElement).toBeInTheDocument()
+describe('App', () => {
+	let comp: RenderResult
+
+	beforeEach(() => {
+		comp = render(
+			<MemoryRouter initialEntries={['/']} initialIndex={0}>
+				<Route path={['/tabs/:tabId', '/tabs', '/']}>
+					<App />
+				</Route>
+			</MemoryRouter>
+		)
+	})
+
+	it('matches loading snapshot', () => {
+		expect(comp.asFragment()).toMatchSnapshot()
+	})
+
+	describe('when loaded', () => {
+		beforeEach(async () => {
+			await waitFor(() => comp.getByTestId('app'))
+		})
+
+		it('displays footer text', () => {
+			expect(comp.getByText(/© 2021 Anthony Williams/i)).toBeInTheDocument()
+		})
+
+		it('displays header text', () => {
+			expect(comp.getByText(/TS Playground/i)).toBeInTheDocument()
+		})
+
+		it('matches snapshot', () => {
+			expect(comp.asFragment()).toMatchSnapshot()
+		})
+	})
 })

--- a/src/App/App.test.tsx
+++ b/src/App/App.test.tsx
@@ -38,3 +38,39 @@ describe('App', () => {
 		})
 	})
 })
+
+describe('App w/ initialTab=2', () => {
+	let comp: RenderResult
+
+	beforeEach(() => {
+		comp = render(
+			<MemoryRouter initialEntries={['/tabs/2']} initialIndex={0}>
+				<Route path={['/tabs/:tabId', '/tabs', '/']}>
+					<App initialTab={2} />
+				</Route>
+			</MemoryRouter>
+		)
+	})
+
+	it('matches loading snapshot', () => {
+		expect(comp.asFragment()).toMatchSnapshot()
+	})
+})
+
+describe('App w/ initialTab=3', () => {
+	let comp: RenderResult
+
+	beforeEach(() => {
+		comp = render(
+			<MemoryRouter initialEntries={['/tabs/3']} initialIndex={0}>
+				<Route path={['/tabs/:tabId', '/tabs', '/']}>
+					<App initialTab={3} />
+				</Route>
+			</MemoryRouter>
+		)
+	})
+
+	it('matches loading snapshot', () => {
+		expect(comp.asFragment()).toMatchSnapshot()
+	})
+})

--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -8,12 +8,12 @@ export const App: FC<any> = () => {
 	// useEffect(() => {}, [])
 
 	return (
-		<article className="app">
-			<header className="">
+		<article className="app" data-testid="app">
+			<header>
 				<h3>TS Playground</h3>
 			</header>
 			<Tabs onTabChange={setSelectedTab} selectedTab={selectedTab} />
-			<section className="content">
+			<section className="content" data-testid="content">
 				{selectedTab === 1 && <div>Content 1</div>}
 				{selectedTab === 2 && <div>Content 2</div>}
 				{selectedTab === 3 && <div>Content 3</div>}

--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -2,8 +2,14 @@ import React, { FC, useState } from 'react'
 import { Tabs } from '../Tabs'
 import './App.css'
 
-export const App: FC<any> = () => {
-	const [selectedTab, setSelectedTab] = useState(1)
+export interface AppProps {
+	initialTab?: number
+}
+
+export const App: FC<AppProps> = ({ initialTab }) => {
+	const [selectedTab, setSelectedTab] = useState(
+		initialTab !== undefined ? initialTab : 1
+	)
 
 	// useEffect(() => {}, [])
 

--- a/src/App/__snapshots__/App.test.tsx.snap
+++ b/src/App/__snapshots__/App.test.tsx.snap
@@ -47,7 +47,7 @@ exports[`App matches loading snapshot 1`] = `
 </DocumentFragment>
 `;
 
-exports[`App w/ initialTab=2 matches loading snapshot 1`] = `
+exports[`App w/ initialTab=2 when loaded matches snapshot 1`] = `
 <DocumentFragment>
   <article
     class="app"
@@ -94,7 +94,7 @@ exports[`App w/ initialTab=2 matches loading snapshot 1`] = `
 </DocumentFragment>
 `;
 
-exports[`App w/ initialTab=3 matches loading snapshot 1`] = `
+exports[`App w/ initialTab=3 when loaded matches snapshot 1`] = `
 <DocumentFragment>
   <article
     class="app"

--- a/src/App/__snapshots__/App.test.tsx.snap
+++ b/src/App/__snapshots__/App.test.tsx.snap
@@ -47,6 +47,100 @@ exports[`App matches loading snapshot 1`] = `
 </DocumentFragment>
 `;
 
+exports[`App w/ initialTab=2 matches loading snapshot 1`] = `
+<DocumentFragment>
+  <article
+    class="app"
+    data-testid="app"
+  >
+    <header>
+      <h3>
+        TS Playground
+      </h3>
+    </header>
+    <section
+      class="tabs"
+    >
+      <ul>
+        <li
+          class=""
+        >
+          tab 1
+        </li>
+        <li
+          class="selected"
+        >
+          tab 2
+        </li>
+        <li
+          class=""
+        >
+          tab 3
+        </li>
+      </ul>
+    </section>
+    <section
+      class="content"
+      data-testid="content"
+    >
+      <div>
+        Content 2
+      </div>
+    </section>
+    <footer>
+      © 2021 Anthony Williams
+    </footer>
+  </article>
+</DocumentFragment>
+`;
+
+exports[`App w/ initialTab=3 matches loading snapshot 1`] = `
+<DocumentFragment>
+  <article
+    class="app"
+    data-testid="app"
+  >
+    <header>
+      <h3>
+        TS Playground
+      </h3>
+    </header>
+    <section
+      class="tabs"
+    >
+      <ul>
+        <li
+          class=""
+        >
+          tab 1
+        </li>
+        <li
+          class=""
+        >
+          tab 2
+        </li>
+        <li
+          class="selected"
+        >
+          tab 3
+        </li>
+      </ul>
+    </section>
+    <section
+      class="content"
+      data-testid="content"
+    >
+      <div>
+        Content 3
+      </div>
+    </section>
+    <footer>
+      © 2021 Anthony Williams
+    </footer>
+  </article>
+</DocumentFragment>
+`;
+
 exports[`App when loaded matches snapshot 1`] = `
 <DocumentFragment>
   <article

--- a/src/App/__snapshots__/App.test.tsx.snap
+++ b/src/App/__snapshots__/App.test.tsx.snap
@@ -1,0 +1,95 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`App matches loading snapshot 1`] = `
+<DocumentFragment>
+  <article
+    class="app"
+    data-testid="app"
+  >
+    <header>
+      <h3>
+        TS Playground
+      </h3>
+    </header>
+    <section
+      class="tabs"
+    >
+      <ul>
+        <li
+          class="selected"
+        >
+          tab 1
+        </li>
+        <li
+          class=""
+        >
+          tab 2
+        </li>
+        <li
+          class=""
+        >
+          tab 3
+        </li>
+      </ul>
+    </section>
+    <section
+      class="content"
+      data-testid="content"
+    >
+      <div>
+        Content 1
+      </div>
+    </section>
+    <footer>
+      © 2021 Anthony Williams
+    </footer>
+  </article>
+</DocumentFragment>
+`;
+
+exports[`App when loaded matches snapshot 1`] = `
+<DocumentFragment>
+  <article
+    class="app"
+    data-testid="app"
+  >
+    <header>
+      <h3>
+        TS Playground
+      </h3>
+    </header>
+    <section
+      class="tabs"
+    >
+      <ul>
+        <li
+          class="selected"
+        >
+          tab 1
+        </li>
+        <li
+          class=""
+        >
+          tab 2
+        </li>
+        <li
+          class=""
+        >
+          tab 3
+        </li>
+      </ul>
+    </section>
+    <section
+      class="content"
+      data-testid="content"
+    >
+      <div>
+        Content 1
+      </div>
+    </section>
+    <footer>
+      © 2021 Anthony Williams
+    </footer>
+  </article>
+</DocumentFragment>
+`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1601,21 +1601,21 @@
     "@svgr/plugin-svgo" "^5.5.0"
     loader-utils "^2.0.0"
 
-"@testing-library/dom@^7.28.1":
-  version "7.31.2"
-  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.31.2.tgz#df361db38f5212b88555068ab8119f5d841a8c4a"
-  integrity sha512-3UqjCpey6HiTZT92vODYLPxTBWlM8ZOOjr3LX5F37/VRipW2M1kX6I/Cm4VXzteZqfGfagg8yXywpcOgQBlNsQ==
+"@testing-library/dom@^8.0.0", "@testing-library/dom@^8.10.1":
+  version "8.10.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-8.10.1.tgz#e24fed92ad51c619cf304c6f1410b4c76b1000c0"
+  integrity sha512-rab7vpf1uGig5efWwsCOn9j4/doy+W3VBoUyzX7C4y77u0wAckwc7R8nyH6e2rw0rRzKJR+gWPiAg8zhiFbxWQ==
   dependencies:
     "@babel/code-frame" "^7.10.4"
     "@babel/runtime" "^7.12.5"
     "@types/aria-query" "^4.2.0"
-    aria-query "^4.2.2"
+    aria-query "^5.0.0"
     chalk "^4.1.0"
-    dom-accessibility-api "^0.5.6"
+    dom-accessibility-api "^0.5.9"
     lz-string "^1.4.4"
-    pretty-format "^26.6.2"
+    pretty-format "^27.0.2"
 
-"@testing-library/jest-dom@^5.11.4":
+"@testing-library/jest-dom@^5.14.1":
   version "5.14.1"
   resolved "https://registry.yarnpkg.com/@testing-library/jest-dom/-/jest-dom-5.14.1.tgz#8501e16f1e55a55d675fe73eecee32cdaddb9766"
   integrity sha512-dfB7HVIgTNCxH22M1+KU6viG5of2ldoA5ly8Ar8xkezKHKXjRvznCdbMbqjYGgO2xjRbwnR+rR8MLUIqF3kKbQ==
@@ -1630,18 +1630,18 @@
     lodash "^4.17.15"
     redent "^3.0.0"
 
-"@testing-library/react@^11.1.0":
-  version "11.2.7"
-  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-11.2.7.tgz#b29e2e95c6765c815786c0bc1d5aed9cb2bf7818"
-  integrity sha512-tzRNp7pzd5QmbtXNG/mhdcl7Awfu/Iz1RaVHY75zTdOkmHCuzMhRL83gWHSgOAcjS3CCbyfwUHMZgRJb4kAfpA==
+"@testing-library/react@^12.1.2":
+  version "12.1.2"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-12.1.2.tgz#f1bc9a45943461fa2a598bb4597df1ae044cfc76"
+  integrity sha512-ihQiEOklNyHIpo2Y8FREkyD1QAea054U0MVbwH1m8N9TxeFz+KoJ9LkqoKqJlzx2JDm56DVwaJ1r36JYxZM05g==
   dependencies:
     "@babel/runtime" "^7.12.5"
-    "@testing-library/dom" "^7.28.1"
+    "@testing-library/dom" "^8.0.0"
 
-"@testing-library/user-event@^12.1.10":
-  version "12.8.3"
-  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-12.8.3.tgz#1aa3ed4b9f79340a1e1836bc7f57c501e838704a"
-  integrity sha512-IR0iWbFkgd56Bu5ZI/ej8yQwrkCv8Qydx6RzwbKz9faXazR/+5tvYKsZQgyXJiwgpcva127YO6JcWy7YlCfofQ==
+"@testing-library/user-event@^13.5.0":
+  version "13.5.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-13.5.0.tgz#69d77007f1e124d55314a2b73fd204b333b13295"
+  integrity sha512-5Kwtbo3Y/NowpkbRuSepbyMFkZmHgD+vPzYB/RJ4oxt5Gj/avFFBYjhw27cqSVPVw/3a67NK1PbiIr9k4Gwmdg==
   dependencies:
     "@babel/runtime" "^7.12.5"
 
@@ -1750,21 +1750,13 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
-"@types/jest@*":
+"@types/jest@*", "@types/jest@^27.0.2":
   version "27.0.2"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-27.0.2.tgz#ac383c4d4aaddd29bbf2b916d8d105c304a5fcd7"
   integrity sha512-4dRxkS/AFX0c5XW6IPMNOydLn2tEhNhJV7DnYK+0bjoJZ+QTmfucBlihX7aoEsh/ocYtkLC73UbnBXBXIxsULA==
   dependencies:
     jest-diff "^27.0.0"
     pretty-format "^27.0.0"
-
-"@types/jest@^26.0.15":
-  version "26.0.24"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.24.tgz#943d11976b16739185913a1936e0de0c4a7d595a"
-  integrity sha512-E/X5Vib8BWqZNRlDxj9vYXhsDwPYbPINqKF9BsnSoon4RQ0D9moEuLD8txgyypFLH7J4+Lho9Nr/c8H0Fi+17w==
-  dependencies:
-    jest-diff "^26.0.0"
-    pretty-format "^26.0.0"
 
 "@types/json-schema@*", "@types/json-schema@^7.0.3", "@types/json-schema@^7.0.5", "@types/json-schema@^7.0.6":
   version "7.0.7"
@@ -1816,17 +1808,17 @@
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.4.tgz#15925414e0ad2cd765bfef58842f7e26a7accb24"
   integrity sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug==
 
-"@types/react-dom@^17.0.0":
+"@types/react-dom@^17.0.2":
   version "17.0.10"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.10.tgz#d6972ec018d23cf22b99597f1289343d99ea9d9d"
   integrity sha512-8oz3NAUId2z/zQdFI09IMhQPNgIbiP8Lslhv39DIDamr846/0spjZK0vnrMak0iB8EKb9QFTTIdg2Wj2zH5a3g==
   dependencies:
     "@types/react" "*"
 
-"@types/react-router-dom@^5.3.1":
-  version "5.3.1"
-  resolved "https://registry.yarnpkg.com/@types/react-router-dom/-/react-router-dom-5.3.1.tgz#76700ccce6529413ec723024b71f01fc77a4a980"
-  integrity sha512-UvyRy73318QI83haXlaMwmklHHzV9hjl3u71MmM6wYNu0hOVk9NLTa0vGukf8zXUqnwz4O06ig876YSPpeK28A==
+"@types/react-router-dom@^5.3.2":
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/@types/react-router-dom/-/react-router-dom-5.3.2.tgz#ebd8e145cf056db5c66eb1dac63c72f52e8542ee"
+  integrity sha512-ELEYRUie2czuJzaZ5+ziIp9Hhw+juEw8b7C11YNA4QdLCVbQ3qLi2l4aq8XnlqM7V31LZX8dxUuFUCrzHm6sqQ==
   dependencies:
     "@types/history" "*"
     "@types/react" "*"
@@ -1840,10 +1832,19 @@
     "@types/history" "*"
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^17.0.0":
+"@types/react@*":
   version "17.0.32"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.32.tgz#89a161286bbe2325d4d516420a27364a324909f4"
   integrity sha512-hAm1pmwA3oZWbkB985RFwNvBRMG0F3KWSiC4/hNmanigKZMiKQoH5Q6etNw8HIDztTGfvXyOjPvdNnvBUCuaPg==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
+"@types/react@^17.0.2":
+  version "17.0.33"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.33.tgz#e01ae3de7613dac1094569880bb3792732203ad5"
+  integrity sha512-pLWntxXpDPaU+RTAuSGWGSEL2FRTNyRQOjSWDke/rxRg14ncsZvx8AKWMWZqvc1UOaJIAoObdZhAWvRaHFi5rw==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -2385,6 +2386,11 @@ aria-query@^4.2.2:
   dependencies:
     "@babel/runtime" "^7.10.2"
     "@babel/runtime-corejs3" "^7.10.2"
+
+aria-query@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.0.0.tgz#210c21aaf469613ee8c9a62c7f86525e058db52c"
+  integrity sha512-V+SM7AbUwJ+EBnB8+DXs0hPZHO0W6pqBcc0dW90OwtVG02PswOu/teuARoLQjdDOH+t9pJgGnW5/Qmouf3gPJg==
 
 arity-n@^1.0.4:
   version "1.0.4"
@@ -4170,7 +4176,7 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
-dom-accessibility-api@^0.5.6:
+dom-accessibility-api@^0.5.6, dom-accessibility-api@^0.5.9:
   version "0.5.9"
   resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.9.tgz#915f8531ba29a50e5c29389dbfb87a9642fef0d6"
   integrity sha512-+KPF4o71fl6NrdnqIrJc6m44NA+Rhf1h7In2MRznejSQasWkjqmHOBUlk+pXJ77cVOSYyZeNHFwn/sjotB6+Sw==
@@ -6344,7 +6350,7 @@ jest-config@^26.6.3:
     micromatch "^4.0.2"
     pretty-format "^26.6.2"
 
-jest-diff@^26.0.0, jest-diff@^26.6.2:
+jest-diff@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-26.6.2.tgz#1aa7468b52c3a68d7d5c5fdcdfcd5e49bd164394"
   integrity sha512-6m+9Z3Gv9wN0WFVasqjCL/06+EFCMTqDEUl/b87HYK2rAPTyfz4ZIuSlPhY51PIQRWx5TaxeF1qmXKe9gfN3sA==
@@ -8848,7 +8854,7 @@ pretty-error@^2.1.1:
     lodash "^4.17.20"
     renderkid "^2.0.4"
 
-pretty-format@^26.0.0, pretty-format@^26.6.0, pretty-format@^26.6.2:
+pretty-format@^26.6.0, pretty-format@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-26.6.2.tgz#e35c2705f14cb7fe2fe94fa078345b444120fc93"
   integrity sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==
@@ -8858,7 +8864,7 @@ pretty-format@^26.0.0, pretty-format@^26.6.0, pretty-format@^26.6.2:
     ansi-styles "^4.0.0"
     react-is "^17.0.1"
 
-pretty-format@^27.0.0, pretty-format@^27.3.1:
+pretty-format@^27.0.0, pretty-format@^27.0.2, pretty-format@^27.3.1:
   version "27.3.1"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.3.1.tgz#7e9486365ccdd4a502061fa761d3ab9ca1b78df5"
   integrity sha512-DR/c+pvFc52nLimLROYjnXPtolawm+uWDxr4FjuLDLUn+ktWnSN851KoHwHzzqq6rfCOjkzN8FLgDrSub6UDuA==
@@ -11138,10 +11144,10 @@ wbuf@^1.1.0, wbuf@^1.7.3:
   dependencies:
     minimalistic-assert "^1.0.0"
 
-web-vitals@^1.0.1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/web-vitals/-/web-vitals-1.1.2.tgz#06535308168986096239aa84716e68b4c6ae6d1c"
-  integrity sha512-PFMKIY+bRSXlMxVAQ+m2aw9c/ioUYfDgrYot0YUa+/xa0sakubWhSDyxAKwzymvXVdF4CZI71g06W+mqhzu6ig==
+web-vitals@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/web-vitals/-/web-vitals-2.1.2.tgz#3a6c8faebf9097a6ccd17f5f45c9485d8d62dab1"
+  integrity sha512-nZnEH8dj+vJFqCRYdvYv0a59iLXsb8jJkt+xvXfwgnkyPdsSLtKNlYmtTDiHmTNGXeSXtpjTTUcNvFtrAk6VMQ==
 
 webidl-conversions@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
This PR

* Adds basic CI/CD (no build or deploy)
    * install dependencies
    * runs unit tests
    * prints test coverage
* Cleans up the package dependency structure
* Adds unit tests for entire app (except clicking tabs)
* Adds several scripts to `package.json` for testing - non-watch and watchful tests, code coverage, snapshot updating
* Adds an optional `initialTab` prop to App's interface